### PR TITLE
Update FormEditorOverrides.yaml

### DIFF
--- a/Configuration/Yaml/FormEditorOverrides.yaml
+++ b/Configuration/Yaml/FormEditorOverrides.yaml
@@ -107,8 +107,6 @@ TYPO3:
                     blindCarbonCopyAddress: ''
                     format: 'html'
                     attachUploads: false
-                    translation:
-                      language: 'default'
               FormEngine:
                 label: 'Double Opt-In'
                 elements:


### PR DESCRIPTION
remove predefinedDefaults translation to prevent Exception while property mapping at property path "": No hmac found for property "options.translation.language"